### PR TITLE
Fix macOS compilation with FPC >= 3.2.0

### DIFF
--- a/GLPT_Cocoa.inc
+++ b/GLPT_Cocoa.inc
@@ -230,10 +230,10 @@ end;
 type
   TBorderlessWindow = objcclass (NSWindow)
     public
-      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id; override;
+      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id; override;
       function initWithContentRect(contentRect: NSRect): id; message 'initWithContentRect:';
-      function canBecomeKeyWindow: boolean; override;
-      function canBecomeMainWindow: boolean; override;
+      function canBecomeKeyWindow: ObjCBool; override;
+      function canBecomeMainWindow: ObjCBool; override;
       procedure setKeepFullScreenAlways (newValue: boolean); message 'setKeepFullScreenAlways:';
     private
       keepFullScreenAlways: boolean;
@@ -241,12 +241,12 @@ type
       procedure dealloc; override;
   end;
 
-function TBorderlessWindow.canBecomeKeyWindow: boolean;
+function TBorderlessWindow.canBecomeKeyWindow: ObjCBool;
 begin
   result := true;
 end;
 
-function TBorderlessWindow.canBecomeMainWindow: boolean;
+function TBorderlessWindow.canBecomeMainWindow: ObjCBool;
 begin
   result := true;
 end;
@@ -271,7 +271,7 @@ begin
   inherited dealloc;
 end;
 
-function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id;
+function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id;
 begin
   result := inherited initWithContentRect_styleMask_backing_defer(contentRect, aStyle, bufferingType, flag);
   if result <> nil then
@@ -442,7 +442,7 @@ type
   TOpenGLView = objcclass (NSView)
     public
       function initWithFrame(frameRect: NSRect): id; override;
-      function isOpaque: Boolean; override;
+      function isOpaque: ObjCBool; override;
     private
       openGLContext: NSOpenGLContext;
       trackingArea: NSTrackingArea;
@@ -556,7 +556,7 @@ begin
     end;
 end;
 
-function TOpenGLView.isOpaque: Boolean;
+function TOpenGLView.isOpaque: ObjCBool;
 begin
   // return false to make the view transparent
   result := window.backgroundColor.alphaComponent > 0;


### PR DESCRIPTION
Since FPC 3.2.0, one has to use `ObjCBool` instead of `Boolean`, otherwise GLPT compilation fails at various overrides because the methods are declared in ancestor with `ObjCBool` (not compatible with Pascal `Boolean`).

E.g. in latest FPC, `packages/cocoaint/src/appkit/NSWindow.inc` defines

```
function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBOOL): instancetype; message 'initWithContentRect:styleMask:backing:defer:';
```

In GLPT, this should be overridden with `flag: ObjCBool`, not `flag: Boolean`.

See https://fpcwiki.coderetro.net/User_Changes_3.2.0#objcbase .