### PR TITLE
Fix swap buffers (update the visible window contents) on macOS

### DIFF
--- a/GLPT_Cocoa.inc
+++ b/GLPT_Cocoa.inc
@@ -537,7 +537,8 @@ end;
 
 procedure TOpenGLView.drawRect(dirtyRect: NSRect);
 begin 
-  openGLContext.flushBuffer;
+  // This has to be done in Cocoa_SwapBuffers, at least on macOS 12
+  // openGLContext.flushBuffer;
 end;
 
 procedure TOpenGLView.reshape;
@@ -725,6 +726,7 @@ end;
 procedure Cocoa_SwapBuffers(win: pGLPTwindow);
 begin
   win^.ref.contentView.display;
+  win^.glcontext.flushBuffer;
 end;
 
 procedure Cocoa_GetFrameBufferSize(win: pGLPTwindow; out width, height: integer);

--- a/GLPT_Cocoa.inc
+++ b/GLPT_Cocoa.inc
@@ -230,10 +230,10 @@ end;
 type
   TBorderlessWindow = objcclass (NSWindow)
     public
-      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id; override;
+      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id; override;
       function initWithContentRect(contentRect: NSRect): id; message 'initWithContentRect:';
-      function canBecomeKeyWindow: boolean; override;
-      function canBecomeMainWindow: boolean; override;
+      function canBecomeKeyWindow: ObjCBool; override;
+      function canBecomeMainWindow: ObjCBool; override;
       procedure setKeepFullScreenAlways (newValue: boolean); message 'setKeepFullScreenAlways:';
     private
       keepFullScreenAlways: boolean;
@@ -241,12 +241,12 @@ type
       procedure dealloc; override;
   end;
 
-function TBorderlessWindow.canBecomeKeyWindow: boolean;
+function TBorderlessWindow.canBecomeKeyWindow: ObjCBool;
 begin
   result := true;
 end;
 
-function TBorderlessWindow.canBecomeMainWindow: boolean;
+function TBorderlessWindow.canBecomeMainWindow: ObjCBool;
 begin
   result := true;
 end;
@@ -271,7 +271,7 @@ begin
   inherited dealloc;
 end;
 
-function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id;
+function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id;
 begin
   result := inherited initWithContentRect_styleMask_backing_defer(contentRect, aStyle, bufferingType, flag);
   if result <> nil then
@@ -442,7 +442,7 @@ type
   TOpenGLView = objcclass (NSView)
     public
       function initWithFrame(frameRect: NSRect): id; override;
-      function isOpaque: Boolean; override;
+      function isOpaque: ObjCBool; override;
     private
       openGLContext: NSOpenGLContext;
       trackingArea: NSTrackingArea;
@@ -556,7 +556,7 @@ begin
     end;
 end;
 
-function TOpenGLView.isOpaque: Boolean;
+function TOpenGLView.isOpaque: ObjCBool;
 begin
   // return false to make the view transparent
   result := window.backgroundColor.alphaComponent > 0;


### PR DESCRIPTION
( Note: This branch is done on top of https://github.com/daar/GLPT/pull/14 . Once you apply https://github.com/daar/GLPT/pull/14 , this PR will contain only 1 commit. )

I'm testing GLPT on macOS 12.3.1 x86_64 . (I do not have a physical machine, I'm actually using remote session to a macOS machine provided by MacStadium for _Castle Game Engine_ development.)

Observed problem: The screen contents do not update. E.g. `./gears` run and look like a static image, even though adding logs shows that `angle += 0.02;` is done and the screen is redrawn. Same with triangle in `./simple` demo. The demo `./two_windows` is a bit weird, with windows updating irregularly once you move them.

This suggests a problem with not doing OpenGL "swap buffers". I see that `TOpenGLView.drawRect` calls `openGLContext.flushBuffer` (which should swap buffers, https://developer.apple.com/documentation/appkit/nsopenglcontext/1436211-flushbuffer ), but it does not seem to do anything on my setup. Doing it from `Cocoa_SwapBuffers` makes things update reliably.

Reading Apple docs, and with my zero Cocoa knowledge today, I cannot really tell *why* does the change work. Reading docs https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_drawing/opengl_drawing.html , they show using `[context flushBuffer];` from `-(void) drawRect`, so exactly what you're doing before the PR. Yet it doesn't work for me, moving it to `Cocoa_SwapBuffers` works.