### PR TITLE
Fix attributes count

### DIFF
--- a/GLPT_Cocoa.inc
+++ b/GLPT_Cocoa.inc
@@ -575,7 +575,7 @@ const
   NSOpenGLProfileVersion3_2Core = $3200 { available in 10_7 };
   NSOpenGLProfileVersion4_1Core = $4100 { available in 10_10 };
 var
-  attributes: array[0..4] of NSOpenGLPixelFormatAttribute;
+  attributes: array[0..32] of NSOpenGLPixelFormatAttribute;
   i: integer = -1;
   context: GLPT_Context;
 begin

--- a/GLPT_Cocoa.inc
+++ b/GLPT_Cocoa.inc
@@ -230,10 +230,10 @@ end;
 type
   TBorderlessWindow = objcclass (NSWindow)
     public
-      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id; override;
+      function initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id; override;
       function initWithContentRect(contentRect: NSRect): id; message 'initWithContentRect:';
-      function canBecomeKeyWindow: boolean; override;
-      function canBecomeMainWindow: boolean; override;
+      function canBecomeKeyWindow: ObjCBool; override;
+      function canBecomeMainWindow: ObjCBool; override;
       procedure setKeepFullScreenAlways (newValue: boolean); message 'setKeepFullScreenAlways:';
     private
       keepFullScreenAlways: boolean;
@@ -241,12 +241,12 @@ type
       procedure dealloc; override;
   end;
 
-function TBorderlessWindow.canBecomeKeyWindow: boolean;
+function TBorderlessWindow.canBecomeKeyWindow: ObjCBool;
 begin
   result := true;
 end;
 
-function TBorderlessWindow.canBecomeMainWindow: boolean;
+function TBorderlessWindow.canBecomeMainWindow: ObjCBool;
 begin
   result := true;
 end;
@@ -271,7 +271,7 @@ begin
   inherited dealloc;
 end;
 
-function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: boolean): id;
+function TBorderlessWindow.initWithContentRect_styleMask_backing_defer (contentRect: NSRect; aStyle: NSUInteger; bufferingType: NSBackingStoreType; flag: ObjCBool): id;
 begin
   result := inherited initWithContentRect_styleMask_backing_defer(contentRect, aStyle, bufferingType, flag);
   if result <> nil then
@@ -442,7 +442,7 @@ type
   TOpenGLView = objcclass (NSView)
     public
       function initWithFrame(frameRect: NSRect): id; override;
-      function isOpaque: Boolean; override;
+      function isOpaque: ObjCBool; override;
     private
       openGLContext: NSOpenGLContext;
       trackingArea: NSTrackingArea;
@@ -556,7 +556,7 @@ begin
     end;
 end;
 
-function TOpenGLView.isOpaque: Boolean;
+function TOpenGLView.isOpaque: ObjCBool;
 begin
   // return false to make the view transparent
   result := window.backgroundColor.alphaComponent > 0;


### PR DESCRIPTION
( Note: This branch is done on top of https://github.com/daar/GLPT/pull/14 . Once you apply https://github.com/daar/GLPT/pull/14 , this PR will contain only 1 commit. )

The `TOpenGLView.defaultPixelFormat` declares local array 

```
attributes: array[0..4] of NSOpenGLPixelFormatAttribute;
```

but this size is too small. The code inside the `TOpenGLView.defaultPixelFormat` wants this list to have *at least* size of 10, looking at various lines `attributes[Inc(i)] := ...`. It currently crashes, as even the default execution needs more size than 5.

I looked at fork from @genericptr and followed the solution from there ( https://github.com/genericptr/GLPT/blob/16dcec0a632dfeed0bcb0b07938a0a2fc16490be/include/GLPT_Cocoa.inc#L654 ):

```
attributes: array[0..32] of NSOpenGLPixelFormatAttribute;
```

This means size 33, safely more than we need.

Note: I found this error while testing Cocoa integration code. I tested it by running GLPT examples, and also because I was basing Cocoa backend of TCastleWindow in _Castle Game Engine_ on GLPT code. See https://castle-engine.io/wp/2022/05/29/huge-improvements-for-macos-users-macos-binary-beta-release-cocoa-backend-for-tcastlewindow-automatic-running-and-packing-using-appbundle-access-to-macos-thanks-to-macstadium/ and https://github.com/castle-engine/castle-engine/blob/master/src/window/castlewindow_cocoa.inc about Cocoa+Castle Game Engine. Thank you very much for creating GLPT, I appreciate greatly that I could use a lot of GLPT code to have a ready solution in CGE.